### PR TITLE
[BUGFIX] fix asset serving logic

### DIFF
--- a/oarepo_whitenoise/version.py
+++ b/oarepo_whitenoise/version.py
@@ -1,3 +1,3 @@
 """Defines version of this package."""
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'

--- a/oarepo_whitenoise/wsgi.py
+++ b/oarepo_whitenoise/wsgi.py
@@ -23,18 +23,19 @@ class IndexWhiteNoise(WhiteNoise):
         """Call api or whitenoise"""
         path = decode_path_info(environ.get("PATH_INFO", ""))
 
-        if 'html' in environ.get('HTTP_ACCEPT', '') and not any([path.startswith(r) for r in API_ROUTES]):
+        if not any([path.startswith(r) for r in API_ROUTES]):
             if self.autorefresh:
                 static_file = self.find_file(path)
             else:
                 static_file = self.files.get(path)
-            if static_file is None:
+
+            if static_file is None and 'html' in environ.get('HTTP_ACCEPT', ''):
                 if self.autorefresh:
                     static_file = self.find_file('/index.html')
                 else:
                     static_file = self.files.get('/index.html')
-
-            return self.serve(static_file, environ, start_response)
+            if static_file:
+                return self.serve(static_file, environ, start_response)
 
         return self.application(environ, start_response)
 


### PR DESCRIPTION
if request path:
  1) is in API_ROUTES -> serve API
  2) is found in WHITENOISE_ROOT -> serve UI
  3) not found in WHITENOISE_ROOT but HTTP_ACCEPT == html -> serve index.html
  4) in any other case -> serve API